### PR TITLE
add --try-secret-key "$Conf_signkey" to PRIVDECRYPT to work with gpg2.1

### DIFF
--- a/git-remote-gcrypt
+++ b/git-remote-gcrypt
@@ -342,7 +342,7 @@ PRIVDECRYPT()
 {
 	local status_=
 	exec 4>&1 &&
-	status_=$(rungpg --status-fd 3 -q -d 3>&1 1>&4) &&
+	status_=$(rungpg --try-secret-key "$Conf_signkey" --status-fd 3 -q -d 3>&1 1>&4) &&
 	xfeed "$status_" grep "^\[GNUPG:\] ENC_TO " >/dev/null &&
 	(xfeed "$status_" grep -e "$1" >/dev/null || {
 		echo_info "Failed to verify manifest signature!" &&


### PR DESCRIPTION
GPG 2.1.1 fails with 'No secret key' when doing a git pull.
This commit, sets gpg to try to decrypt the files using the $Conf-signkey key

(not sure if anyone is maintaining this, but your tree seems to be the one with the most recent commits)